### PR TITLE
Update stable joe day data

### DIFF
--- a/subgraphs/stablejoe/src/entities/daydata.ts
+++ b/subgraphs/stablejoe/src/entities/daydata.ts
@@ -11,7 +11,7 @@ export function getStableJoeDayData(eventAddress: Address, block: ethereum.Block
 
   if (dayData === null) {
     dayData = new StableJoeDayData(id)
-    dayData.date = day
+    dayData.date = day * SECONDS_PER_DAY
     dayData.totalJoeStaked = BIG_DECIMAL_ZERO
     dayData.joeStaked = BIG_DECIMAL_ZERO
     dayData.joeStakedUSD = BIG_DECIMAL_ZERO

--- a/subgraphs/stablejoe/src/entities/daydata.ts
+++ b/subgraphs/stablejoe/src/entities/daydata.ts
@@ -12,6 +12,7 @@ export function getStableJoeDayData(eventAddress: Address, block: ethereum.Block
   if (dayData === null) {
     dayData = new StableJoeDayData(id)
     dayData.date = day
+    dayData.totalJoeStaked = BIG_DECIMAL_ZERO
     dayData.joeStaked = BIG_DECIMAL_ZERO
     dayData.joeStakedUSD = BIG_DECIMAL_ZERO
     dayData.joeUnstaked = BIG_DECIMAL_ZERO

--- a/subgraphs/stablejoe/src/mappings/stablejoe.ts
+++ b/subgraphs/stablejoe/src/mappings/stablejoe.ts
@@ -141,6 +141,7 @@ export function handleDeposit(event: DepositEvent): void {
   log.debug('[handleDeposit] update day data {}', [event.address.toHexString()])
   // update day data
   let stableJoeDayData = getStableJoeDayData(event.address, event.block)
+  stableJoeDayData.totalJoeStaked = stableJoe.joeStaked
   stableJoeDayData.joeStaked = stableJoeDayData.joeStaked.plus(convertAmountToDecimal(event.params.amount))
   stableJoeDayData.joeStakedUSD = stableJoeDayData.joeStakedUSD.plus(
     convertAmountToDecimal(event.params.amount).times(getJoePrice())
@@ -180,6 +181,7 @@ export function handleWithdraw(event: WithdrawEvent): void {
 
   // update day data
   let stableJoeDayData = getStableJoeDayData(event.address, event.block)
+  stableJoeDayData.totalJoeStaked = stableJoe.joeStaked
   stableJoeDayData.joeUnstaked = stableJoeDayData.joeUnstaked.plus(convertAmountToDecimal(event.params.amount))
   stableJoeDayData.joeUnstakedUSD = stableJoeDayData.joeUnstakedUSD.plus(
     convertAmountToDecimal(event.params.amount).times(joePrice)

--- a/subgraphs/stablejoe/stablejoe.graphql
+++ b/subgraphs/stablejoe/stablejoe.graphql
@@ -52,6 +52,7 @@ type User @entity {
 type StableJoeDayData @entity {
   id: ID!
   date: Int!
+  totalJoeStaked: BigDecimal!
   joeStaked: BigDecimal!
   joeStakedUSD: BigDecimal!
   joeUnstaked: BigDecimal!


### PR DESCRIPTION
This PR adds `totalJoeStaked` to the stable joe day data entity: we need it to calculate the APR for the history chart in the analytics dashboard.