### PR TITLE
Enable fulltext search on exchange subgraph - Pair entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ typings/
 
 build/
 generated/
+
+# Data from local node ran by docker
+graph_data/

--- a/README.md
+++ b/README.md
@@ -62,5 +62,15 @@ For any of the subgraphs:
 3. Run `graph auth https://api.thegraph.com/deploy/ <ACCESS_TOKEN>`
 4. Deploy via `yarn run deploy:[subgraph]`.
 
+## To setup local graph-node
+
+1. Install docker on local machine https://docs.docker.com/get-docker/)
+2. Run `yarn start:node` 
+3. Build constants: `cd packages/constants && yarn prepare:fuji`
+4. Build subgraph: `cd subgraphs/exchange && yarn prepare:fuji && yarn codegen:fuji && yarn build:fuji`
+5. Create local subgraph: `cd subgraphs/exchange && yarn create-local && yarn deploy-local`
+6. Subgraph endpoint available at http://localhost:8000/subgraphs/name/traderjoe-xyz/exchange-fuji 
+
+
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3"
+services:
+  graph-node:
+    container_name: joe_indexer
+    image: graphprotocol/graph-node:v0.23.1
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+      - "8020:8020"
+      - "8030:8030"
+      - "8040:8040"
+    depends_on:
+      - ipfs
+      - postgres
+    environment:
+      postgres_host: postgres
+      postgres_user: graph-node
+      postgres_pass: let-me-in
+      postgres_db: graph-node
+      ipfs: "ipfs:5001"
+      GRAPH_ETH_CALL_BY_NUMBER: 1
+      GRAPH_NO_EIP_1898_SUPPORT: 1
+      GRAPH_ALLOW_NON_DETERMINISTIC_IPFS: 1
+      GRAPH_ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: 1
+      ethereum: "fuji:https://api.avax-test.network/ext/bc/C/rpc"
+      RUST_LOG: info
+  ipfs:
+    container_name: ipfs
+    image: ipfs/go-ipfs:v0.4.23
+    ports:
+      - "5001:5001"
+    volumes:
+      - ./graph_data/ipfs:/data/ipfs
+  postgres:
+    image: postgres
+    ports:
+      - "5432:5432"
+    command: ["postgres", "-cshared_preload_libraries=pg_stat_statements"]
+    environment:
+      POSTGRES_USER: graph-node
+      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_DB: graph-node
+    volumes:
+      - ./graph_data/postgres:/var/lib/postgresql/data

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "codegen": "yarn workspaces run codegen",
     "prepare:avax": "yarn workspaces run prepare:avax",
     "prepare:fuji": "yarn workspaces run prepare:fuji",
-    "prepare:rinkeby": "yarn workspaces run prepare:rinkeby"
+    "prepare:rinkeby": "yarn workspaces run prepare:rinkeby",
+    "start:node": "docker-compose up -d"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.20.0",

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -32,55 +32,55 @@ export const LOCKUP_POOL_NUMBER = BigInt.fromI32(29)
 export const NULL_CALL_RESULT_VALUE = '0x0000000000000000000000000000000000000000000000000000000000000001'
 
 // EXCHANGE
-export const FACTORY_ADDRESS = Address.fromString('0xF5c7d9733e5f53abCC1695820c4818C59B457C2C')
-export const TRADERJOE_START_BLOCK = BigInt.fromI32(10220115)
+export const FACTORY_ADDRESS = Address.fromString('0x9ad6c38be94206ca50bb0d90783181662f0cfa10')
+export const TRADERJOE_START_BLOCK = BigInt.fromI32(2486000)
 
-export const JOE_TOKEN_ADDRESS = Address.fromString('0x477Fd10Db0D80eAFb773cF623B258313C3739413')
+export const JOE_TOKEN_ADDRESS = Address.fromString('0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd')
 
 // MASTER CHEF
 export const MASTER_CHEF_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000')
-export const MASTER_CHEF_V2_ADDRESS = Address.fromString('0xEAA9637E54D4Da88d7A56E797C2EAa4950111033')
-export const MASTER_CHEF_V3_ADDRESS = Address.fromString('0x47e4B09651D76609e902183c2315b0638fa8375E')
-export const BOOSTED_MASTER_CHEF_ADDRESS = Address.fromString('0xEE7B7871755bCe3CD1B0aa1d01320Dd311b08279')
+export const MASTER_CHEF_V2_ADDRESS = Address.fromString('0xd6a4f121ca35509af06a0be99093d08462f53052')
+export const MASTER_CHEF_V3_ADDRESS = Address.fromString('0x188bed1968b795d5c9022f6a0bb5931ac4c18f00')
+export const BOOSTED_MASTER_CHEF_ADDRESS = Address.fromString('0x4483f0b6e2F5486D06958C20f8C39A7aBe87bf8F')
 
-export const MASTER_CHEF_START_BLOCK = BigInt.fromI32(9539146)
+export const MASTER_CHEF_START_BLOCK = BigInt.fromI32(2486000)
 
 // BAR
-export const JOE_BAR_ADDRESS = Address.fromString('0x200BdB3Ed6bF347421329FdbF1813dE87F1A456a')
+export const JOE_BAR_ADDRESS = Address.fromString('0x57319d41f71e81f3c65f2a47ca4e001ebafd4f33')
 
 // MAKER
-export const JOE_MAKER_ADDRESS = Address.fromString('0x5b57Fef4e7f82f6c57a7Aca851Bc8c02F9AD3Bc5')
-export const JOE_MAKER_V2_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000')
+export const JOE_MAKER_ADDRESS = Address.fromString('0x861726bfe27931a4e22a7277bde6cb8432b65856')
+export const JOE_MAKER_V2_ADDRESS = Address.fromString('0xC98C3C547DDbcc0029F38E0383C645C202aD663d')
 
 // PRICING
-export const TRADERJOE_WAVAX_USDT_PAIR_ADDRESS = Address.fromString('0xb6f0758f374b3c570e8073ec8f552c9b2db939f3')
-export const JOE_USDT_PAIR_ADDRESS = Address.fromString('0xd520cf33c013909afc9cf158d73f5460753b5ec4')
+export const TRADERJOE_WAVAX_USDT_PAIR_ADDRESS = Address.fromString('0xed8cbd9f0ce3c6986b22002f03c6475ceb7a6256')
+export const JOE_USDT_PAIR_ADDRESS = Address.fromString('0x1643de2efb8e35374d796297a9f95f64c082a8ce')
 
 // VEJOE 
-export const VEJOE_TOKEN_ADDRESS = Address.fromString('0x8043E85a15c7F4Ad58a24712Cf08C624B52fAa34')
+export const VEJOE_TOKEN_ADDRESS = Address.fromString('0x3cabf341943Bc8466245e4d6F1ae0f8D071a1456')
 
-export const WAVAX_ADDRESS = Address.fromString('0xd00ae08403B9bbb9124bB305C09058E32C39A48c')
-export const USDT_ADDRESS = Address.fromString('0x3763fb99d772d1d96571f39508e34489f400750c')
-export const USDC_E_ADDRESS = Address.fromString('0x950c6f4f97dd62bd3ca76f084663224fd2e6b555')
-export const USDC_ADDRESS = Address.fromString('0x950c6f4f97dd62bd3ca76f084663224fd2e6b555')
-export const WBTC_ADDRESS = Address.fromString('0x106Dc78d638527b84572e5B077B76250adD0A988')
-export const MIM_ADDRESS = Address.fromString('0x950c6f4f97dd62bd3ca76f084663224fd2e6b555')
+export const WAVAX_ADDRESS = Address.fromString('0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7')
+export const USDT_ADDRESS = Address.fromString('0xc7198437980c041c805a1edcba50c1ce5db95118')
+export const USDC_E_ADDRESS = Address.fromString('0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664')
+export const USDC_ADDRESS = Address.fromString('0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e')
+export const WBTC_ADDRESS = Address.fromString('0x50b7545627a5162f82a992c33b87adc75187b218')
+export const MIM_ADDRESS = Address.fromString('0x130966628846bfd36ff31a822705796e8cb8c18d')
 
 export const WAVAX_STABLE_PAIRS: string[] = [
-    '0xb6f0758f374b3c570e8073ec8f552c9b2db939f3', // WAVAX-USDT
-    '0xb6f0758f374b3c570e8073ec8f552c9b2db939f3', // WAVAX-DAI
-    '0x0c01abf914b0c4554d9da66167293b10c312fe57', // WAVAX-USDC
-    '0x0c01abf914b0c4554d9da66167293b10c312fe57', // WAVAX-USDC
+    '0xed8cbd9f0ce3c6986b22002f03c6475ceb7a6256', // WAVAX-USDT
+    '0x87dee1cc9ffd464b79e058ba20387c1984aed86a', // WAVAX-DAI
+    '0xa389f9430876455c36478deea9769b7ca4e3ddb1', // WAVAX-USDC
+    '0x781655d802670bba3c89aebaaea59d3182fd755d', // WAVAX-USDC
 ]
 
 export const WHITELIST: string[] = [
-    '0xd00ae08403B9bbb9124bB305C09058E32C39A48c', // WAVAX
-    '0x1886d09c9ade0c5db822d85d21678db67b6c2982', // WETH
-    '0x106Dc78d638527b84572e5B077B76250adD0A988', // WBTC
-    '0x3763fb99d772d1d96571f39508e34489f400750c', // USDT
-    '0x3763fb99d772d1d96571f39508e34489f400750c', // DAI
-    '0x950c6f4f97dd62bd3ca76f084663224fd2e6b555', // USDC
-    '0x950c6f4f97dd62bd3ca76f084663224fd2e6b555', // MIM
+    '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7', // WAVAX
+    '0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab', // WETH
+    '0x50b7545627a5162f82a992c33b87adc75187b218', // WBTC
+    '0xc7198437980c041c805a1edcba50c1ce5db95118', // USDT
+    '0xd586e7f844cea2f87f50152665bcbc2c279d8d70', // DAI
+    '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e', // USDC
+    '0x130966628846bfd36ff31a822705796e8cb8c18d', // MIM
 ]
 
 // LOCKUP -- TO BE DEPRECATED?

--- a/subgraphs/exchange/exchange.avax.yaml
+++ b/subgraphs/exchange/exchange.avax.yaml
@@ -20,17 +20,17 @@ dataSources:
         - Factory
       abis:
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: JoeToken
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeToken.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeToken.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
         - name: ERC20SymbolBytes
-          file: ../../packages/abis/ERC20SymbolBytes.json
+          file: ./packages/abis/ERC20SymbolBytes.json
         - name: ERC20NameBytes
-          file: ../../packages/abis/ERC20NameBytes.json
+          file: ./packages/abis/ERC20NameBytes.json
       eventHandlers:
         - event: PairCreated(indexed address,indexed address,address,uint256)
           handler: onPairCreated
@@ -59,9 +59,9 @@ templates:
         - User
       abis:
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
       eventHandlers:
         - event: Mint(indexed address,uint256,uint256)
           handler: onMint

--- a/subgraphs/exchange/exchange.fuji.yaml
+++ b/subgraphs/exchange/exchange.fuji.yaml
@@ -20,17 +20,17 @@ dataSources:
         - Factory
       abis:
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: JoeToken
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeToken.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeToken.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
         - name: ERC20SymbolBytes
-          file: ../../packages/abis/ERC20SymbolBytes.json
+          file: ./packages/abis/ERC20SymbolBytes.json
         - name: ERC20NameBytes
-          file: ../../packages/abis/ERC20NameBytes.json
+          file: ./packages/abis/ERC20NameBytes.json
       eventHandlers:
         - event: PairCreated(indexed address,indexed address,address,uint256)
           handler: onPairCreated
@@ -59,9 +59,9 @@ templates:
         - User
       abis:
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
       eventHandlers:
         - event: Mint(indexed address,uint256,uint256)
           handler: onMint

--- a/subgraphs/exchange/exchange.graphql
+++ b/subgraphs/exchange/exchange.graphql
@@ -8,12 +8,12 @@ type _Schema_
   #   include: [{ entity: "Token", fields: [{ name: "id" }, { name: "name" }, { name: "symbol" }] }]
   # )
   # Pair
-  # @fulltext(
-  #   name: "pairSearch"
-  #   language: en
-  #   algorithm: rank
-  #   include: [{ entity: "Pair", fields: [{ name: "id" }, { name: "name" }] }]
-  # )
+  @fulltext(
+    name: "pairSearch"
+    language: en
+    algorithm: rank
+    include: [{ entity: "Pair", fields: [{ name: "id" }, { name: "name" }] }]
+  )
   # User
   # @fulltext(name: "userSearch", language: en, algorithm: rank, include: [{ entity: "User", fields: [{ name: "id" }] }])
 

--- a/subgraphs/exchange/exchange.template.yaml
+++ b/subgraphs/exchange/exchange.template.yaml
@@ -20,17 +20,17 @@ dataSources:
         - Factory
       abis:
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: JoeToken
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeToken.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeToken.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
         - name: ERC20SymbolBytes
-          file: ../../packages/abis/ERC20SymbolBytes.json
+          file: ./packages/abis/ERC20SymbolBytes.json
         - name: ERC20NameBytes
-          file: ../../packages/abis/ERC20NameBytes.json
+          file: ./packages/abis/ERC20NameBytes.json
       eventHandlers:
         - event: PairCreated(indexed address,indexed address,address,uint256)
           handler: onPairCreated
@@ -59,9 +59,9 @@ templates:
         - User
       abis:
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
       eventHandlers:
         - event: Mint(indexed address,uint256,uint256)
           handler: onMint

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,35 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@graphprotocol/graph-cli@0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.26.0.tgz#9bcc3533d1384d44b65e0bf7eef81221ae8a4e05"
+  integrity sha512-sQKKfkGy6jsfpZD6KA9KdvHRpeStd1ZH334CMVxhyJtPY006a/Wc2rr7TBqgAtwpggs7UiT0UA3s5vG0jFQB5g==
+  dependencies:
+    assemblyscript "0.19.10"
+    binary-install-raw "0.0.13"
+    chalk "^3.0.0"
+    chokidar "^3.0.2"
+    debug "^4.1.1"
+    docker-compose "^0.23.2"
+    dockerode "^2.5.8"
+    fs-extra "^9.0.0"
+    glob "^7.1.2"
+    gluegun "https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep"
+    graphql "^15.5.0"
+    immutable "^3.8.2"
+    ipfs-http-client "^34.0.0"
+    jayson "^3.0.2"
+    js-yaml "^3.13.1"
+    node-fetch "^2.3.0"
+    pkginfo "^0.4.1"
+    prettier "^1.13.5"
+    request "^2.88.0"
+    semver "7.3.5"
+    tmp-promise "^3.0.2"
+    which "2.0.2"
+    yaml "^1.5.1"
+
 "@graphprotocol/graph-cli@^0.20.0":
   version "0.20.1"
   resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.20.1.tgz#659459091821861987e6596b46e692ca4a3c2b3b"
@@ -72,6 +101,13 @@
     yaml "^1.5.1"
   optionalDependencies:
     keytar "^7.4.0"
+
+"@graphprotocol/graph-ts@0.24.1":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.24.1.tgz#50961b52b5383f9c5cf5e6e23fa039f24e729ddf"
+  integrity sha512-2vU4m5ZPQIqMlMce/z5vmOtGHRlRmcRhMfemS3NIwxCSxSBGVnX2zb7QBTzzdQKGwsAZdbz6V0okkOtvohELfQ==
+  dependencies:
+    assemblyscript "0.19.10"
 
 "@graphprotocol/graph-ts@^0.20.0":
   version "0.20.1"
@@ -111,7 +147,7 @@
   resolved "https://registry.yarnpkg.com/@traderjoe-xyz/core/-/core-2.3.0.tgz#d43977920cf43c848126eaa021547f2925c6ed81"
   integrity sha512-8iZDTpjQgv0fbmfpIJ/NZAO1yxLRQdAR4/6hPWP3e6KGtCSS9RWKo99o3Iyg+YRZGBsd0p/99wLa5WhEfibjXw==
 
-"@traderjoe-xyz/core@^2.2.2":
+"@traderjoe-xyz/core@^2.2.2", "@traderjoe-xyz/core@^2.3.0":
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/@traderjoe-xyz/core/-/core-2.4.6.tgz#d7657530cab4c5e10e6ba09bf955be76b918fa77"
   integrity sha512-YmDEkxa8avXRlILFNT3p87vkXrQ1ONK/Hb3XJiUZxGktTPf4gaAHjAPtETn1LwDBAqLvs2ZhiZDSgHSdDivhNw==
@@ -349,6 +385,14 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apisauce@^1.0.1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-1.1.5.tgz#31d41a5cf805e401266cec67faf1a50f4aeae234"
+  integrity sha512-gKC8qb/bDJsPsnEXLZnXJ7gVx7dh87CEVNeIwv1dvaffnXoh5GHwac5pWR1P2broLiVj/fqFMQvLDDt/RhjiqA==
+  dependencies:
+    axios "^0.21.2"
+    ramda "^0.25.0"
+
 apisauce@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-2.1.5.tgz#546229f8f145711b3b022065afb0f43bd304ecb3"
@@ -408,7 +452,7 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#v0.6":
+assemblyscript@0.19.10, "assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#v0.6":
   version "0.6.0"
   resolved "git+https://github.com/AssemblyScript/assemblyscript.git#3ed76a97f05335504166fce1653da75f4face28f"
   dependencies:
@@ -456,7 +500,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.4:
+axios@^0.21.1, axios@^0.21.2, axios@^0.21.4:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
@@ -496,6 +540,15 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+binary-install-raw@0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/binary-install-raw/-/binary-install-raw-0.0.13.tgz#43a13c6980eb9844e2932eb7a91a56254f55b7dd"
+  integrity sha512-v7ms6N/H7iciuk6QInon3/n2mu7oRX+6knJ9xFPsJ3rQePgAqcR3CRTwUheFd8SLbiq4LL7Z4G/44L9zscdt9A==
+  dependencies:
+    axios "^0.21.1"
+    rimraf "^3.0.2"
+    tar "^6.1.0"
 
 binaryen@77.0.0-nightly.20190407:
   version "77.0.0-nightly.20190407"
@@ -719,6 +772,11 @@ chownr@^1.0.1, chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 cids@~0.7.0, cids@~0.7.1:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.7.5.tgz#60a08138a99bfb69b6be4ceb63bfef7a396b28b2"
@@ -809,6 +867,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colors@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
 colors@^1.1.2, colors@^1.3.3:
   version "1.4.0"
@@ -1419,6 +1482,13 @@ fs-jetpack@^2.2.2:
     minimatch "^3.0.2"
     rimraf "^2.6.3"
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1563,6 +1633,42 @@ gluegun@^4.3.1:
     lodash.upperfirst "^4.3.1"
     ora "^4.0.0"
     pluralize "^8.0.0"
+    semver "^7.0.0"
+    which "^2.0.0"
+    yargs-parser "^16.1.0"
+
+"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
+  version "4.3.1"
+  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
+  dependencies:
+    apisauce "^1.0.1"
+    app-module-path "^2.2.0"
+    cli-table3 "~0.5.0"
+    colors "1.3.3"
+    cosmiconfig "6.0.0"
+    cross-spawn "^7.0.0"
+    ejs "^2.6.1"
+    enquirer "2.3.4"
+    execa "^3.0.0"
+    fs-jetpack "^2.2.2"
+    lodash.camelcase "^4.3.0"
+    lodash.kebabcase "^4.1.1"
+    lodash.lowercase "^4.3.0"
+    lodash.lowerfirst "^4.3.1"
+    lodash.pad "^4.5.1"
+    lodash.padend "^4.6.1"
+    lodash.padstart "^4.6.1"
+    lodash.repeat "^4.1.0"
+    lodash.snakecase "^4.1.1"
+    lodash.startcase "^4.4.0"
+    lodash.trim "^4.5.1"
+    lodash.trimend "^4.5.1"
+    lodash.trimstart "^4.5.1"
+    lodash.uppercase "^4.3.0"
+    lodash.upperfirst "^4.3.1"
+    ora "^4.0.0"
+    pluralize "^8.0.0"
+    ramdasauce "^2.1.0"
     semver "^7.0.0"
     which "^2.0.0"
     yargs-parser "^16.1.0"
@@ -2421,6 +2527,21 @@ minimist@^1.2.3:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
+minipass@^3.0.0:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.4.tgz#ca99f95dd77c43c7a76bf51e6d200025eee0ffae"
+  integrity sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
@@ -2432,6 +2553,11 @@ mkdirp@^0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 ms@2.1.2:
   version "2.1.2"
@@ -2963,6 +3089,23 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+ramda@^0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
+  integrity sha512-HEm619G8PaZMfkqCa23qiOe7r3R0brPu7ZgOsgKUsnvLhd0qhc/vTjkUovomgPWa5ECBa08fJZixth9LaoBo5w==
+
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
+
+ramdasauce@^2.1.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ramdasauce/-/ramdasauce-2.1.3.tgz#acb45ecc7e4fc4d6f39e19989b4a16dff383e9c2"
+  integrity sha512-Ml3CPim4SKwmg5g9UI77lnRSeKr/kQw7YhQ6rfdMcBYy6DMlwmkEwQqjygJ3OhxPR+NfFfpjKl3Tf8GXckaqqg==
+  dependencies:
+    ramda "^0.24.1"
+
 rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -3073,7 +3216,7 @@ rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3139,7 +3282,7 @@ secp256k1@^3.6.2:
     nan "^2.14.0"
     safe-buffer "^5.1.2"
 
-semver@^7.0.0, semver@^7.2.1, semver@^7.3.5:
+semver@7.3.5, semver@^7.0.0, semver@^7.2.1, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -3450,6 +3593,18 @@ tar-stream@^2.0.1, tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
+tar@^6.1.0:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -3468,12 +3623,26 @@ through2@^3.0.0, through2@^3.0.1:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+tmp-promise@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
   integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
   dependencies:
     rimraf "^2.6.3"
+
+tmp@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 to-buffer@^1.1.1:
   version "1.1.1"
@@ -3612,7 +3781,7 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-which@^2.0.0, which@^2.0.1:
+which@2.0.2, which@^2.0.0, which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
**1) Enabled fulltext search**

Added fulltext search capability to the `exchange` subgraph's Pair entity in order to allow searching for liquidity pools directly against the subgraph in Trader Joe interface. 

**2) Set up docker-compose to spin up local node**

Setting up local graph-node as explained in https://github.com/graphprotocol/graph-node is too complicated and requires installing too many dependencies on local machine. Let's use docker instead:

Added docker-compose.yml that runs three docker containers needed to run graph-node: postgres, ipfs, and graphprotocol/graph-node. Code borrowed from [here](https://docs.harmony.one/home/developers/tutorials/the-graph-subgraphs/building-and-deploying-subgraph-local-node)

Updated README with instructions on how to run local graph-node using docker and deploy subgraph to the node

**3) Updated abi import paths on `exchange.template.yaml`** 

TheGraph's IPFS endpoint is blocking uploads with abi imports outside of the subgraph directory. 

Therefore, updated the paths on `exchange.template.yaml` to import from `./packages` and `./node_modules/@traderjoe-xyz/core/abi` within the `subgraphs/exchange` directory
