### PR TITLE
Filter small pairs

### DIFF
--- a/packages/constants/config/avax.json
+++ b/packages/constants/config/avax.json
@@ -34,5 +34,8 @@
   "wavax_usdc_pair_address": "0xa389f9430876455c36478deea9769b7ca4e3ddb1",
   "wavax_mim_pair_address": "0x781655d802670bba3c89aebaaea59d3182fd755d",
 
-  "zero_address": "0x0000000000000000000000000000000000000000"
+  "zero_address": "0x0000000000000000000000000000000000000000",
+
+  "minimum_usd_threshold_new_pairs": "80000",
+  "minimum_liquidity_threshold_avax":"100"
 }

--- a/packages/constants/config/fuji.json
+++ b/packages/constants/config/fuji.json
@@ -34,5 +34,8 @@
   "wavax_dai_pair_address": "0xb6f0758f374b3c570e8073ec8f552c9b2db939f3",
   "wavax_mim_pair_address": "0x0c01abf914b0c4554d9da66167293b10c312fe57",
 
-  "zero_address": "0x0000000000000000000000000000000000000000"
+  "zero_address": "0x0000000000000000000000000000000000000000",
+
+  "minimum_usd_threshold_new_pairs": "0",
+  "minimum_liquidity_threshold_avax":"0"
 }

--- a/packages/constants/index.template.ts
+++ b/packages/constants/index.template.ts
@@ -87,10 +87,10 @@ export const WHITELIST: string[] = [
 export const LOCKUP_BLOCK_NUMBER = BigInt.fromI32(10959148)
 
 // minimum liquidity required to count towards tracked volume for pairs with small # of Lps
-export const MINIMUM_USD_THRESHOLD_NEW_PAIRS = BigDecimal.fromString('0')
+export const MINIMUM_USD_THRESHOLD_NEW_PAIRS = BigDecimal.fromString('80000')
 
 // minimum liquidity for price to get tracked
-export const MINIMUM_LIQUIDITY_THRESHOLD_ETH = BigDecimal.fromString('5')
+export const MINIMUM_LIQUIDITY_THRESHOLD_AVAX = BigDecimal.fromString('100')
 
 // MasterChefV2 precision
 export const ACC_JOE_PRECISION = BigInt.fromString('1000000000000')

--- a/packages/constants/index.template.ts
+++ b/packages/constants/index.template.ts
@@ -87,10 +87,10 @@ export const WHITELIST: string[] = [
 export const LOCKUP_BLOCK_NUMBER = BigInt.fromI32(10959148)
 
 // minimum liquidity required to count towards tracked volume for pairs with small # of Lps
-export const MINIMUM_USD_THRESHOLD_NEW_PAIRS = BigDecimal.fromString('80000')
+export const MINIMUM_USD_THRESHOLD_NEW_PAIRS = BigDecimal.fromString('{{minimum_usd_threshold_new_pairs}}')
 
 // minimum liquidity for price to get tracked
-export const MINIMUM_LIQUIDITY_THRESHOLD_AVAX = BigDecimal.fromString('100')
+export const MINIMUM_LIQUIDITY_THRESHOLD_AVAX = BigDecimal.fromString('{{minimum_liquidity_threshold_avax}}')
 
 // MasterChefV2 precision
 export const ACC_JOE_PRECISION = BigInt.fromString('1000000000000')

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -87,10 +87,10 @@ export const WHITELIST: string[] = [
 export const LOCKUP_BLOCK_NUMBER = BigInt.fromI32(10959148)
 
 // minimum liquidity required to count towards tracked volume for pairs with small # of Lps
-export const MINIMUM_USD_THRESHOLD_NEW_PAIRS = BigDecimal.fromString('0')
+export const MINIMUM_USD_THRESHOLD_NEW_PAIRS = BigDecimal.fromString('80000')
 
 // minimum liquidity for price to get tracked
-export const MINIMUM_LIQUIDITY_THRESHOLD_ETH = BigDecimal.fromString('5')
+export const MINIMUM_LIQUIDITY_THRESHOLD_AVAX = BigDecimal.fromString('100')
 
 // MasterChefV2 precision
 export const ACC_JOE_PRECISION = BigInt.fromString('1000000000000')

--- a/subgraphs/exchange/src/exchange/pricing.ts
+++ b/subgraphs/exchange/src/exchange/pricing.ts
@@ -10,6 +10,7 @@ import {
   USDT_ADDRESS,
   JOE_TOKEN_ADDRESS,
   TRADERJOE_START_BLOCK,
+  MINIMUM_LIQUIDITY_THRESHOLD_AVAX
 } from 'const'
 import { Address, BigDecimal, ethereum, log } from '@graphprotocol/graph-ts'
 import { Pair, Token } from '../../generated/schema'
@@ -133,11 +134,11 @@ export function getAvaxRate(address: Address): BigDecimal {
 
     if (pairAddress != ADDRESS_ZERO) {
       const pair = Pair.load(pairAddress.toHex())
-      if (pair.token0 == address.toHexString()) {
+      if (pair.token0 == address.toHexString() && pair.reserveAVAX.gt(MINIMUM_LIQUIDITY_THRESHOLD_AVAX)) {
         const token1 = Token.load(pair.token1)
         return pair.token1Price.times(token1.derivedAVAX as BigDecimal) // return token1 per our token * AVAX per token 1
       }
-      if (pair.token1 == address.toHexString()) {
+      if (pair.token1 == address.toHexString() && pair.reserveAVAX.gt(MINIMUM_LIQUIDITY_THRESHOLD_AVAX)) {
         const token0 = Token.load(pair.token0)
         return pair.token0Price.times(token0.derivedAVAX as BigDecimal) // return token0 per our token * AVAX per token 0
       }


### PR DESCRIPTION
This PR filters small pairs to meet follow criteria before we track volumes:
- If pair has low number of liquidity providers (<5) then liquidity should be high (>USD100K)
- If pair has low liquidity (<100 AVAX), we don't track avax pricing

**Scenario:**
- User creates new pair, `SCAM-AVAX`, by depositing 0.00001 AVAX to 1 SCAM. The price of SCAM is 100,000 AVAX (~USD $2M) 
- User adds liquidity to `SCAM-USD` by depositing 1 SCAM to 100 USD. The volume is 2,000,100 USD. 

**Expected Result:**
- `SCAM-AVAX` liquidity too low, SCAM token doesn't have a tracked price. Volume will be 0. 
