### PR TITLE
Set up to prevent ipfs upload error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@traderjoe-xyz/subgraphs",
   "private": true,
-  "workspaces": [
-    "packages/*",
-    "subgraphs/*"
-  ],
+  "workspaces": {
+    "packages": [
+      "packages/*",
+      "subgraphs/*"
+    ],
+    "nohoist": ["**/@traderjoe-xyz/core"]
+  },
   "resolutions": {
     "assemblyscript": "git+https://github.com/AssemblyScript/assemblyscript.git#v0.6"
   },

--- a/subgraphs/bar/bar.template.yaml
+++ b/subgraphs/bar/bar.template.yaml
@@ -20,11 +20,11 @@ dataSources:
         - User
       abis:
         - name: Bar
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeBar.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeBar.json
         - name: JoeToken
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeToken.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeToken.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: transfer

--- a/subgraphs/bar/package.json
+++ b/subgraphs/bar/package.json
@@ -22,5 +22,8 @@
         "create-local": "graph create --node http://localhost:8020/ traderjoe-xyz/bar",
         "remove-local": "graph remove --node http://localhost:8020/ traderjoe-xyz/bar",
         "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 traderjoe-xyz/bar bar.fuji.yaml"
+    },
+    "dependencies": {
+        "@traderjoe-xyz/core": "^2.3.0"
     }
 }

--- a/subgraphs/boostedMasterchef/boostedMasterchef.template.yaml
+++ b/subgraphs/boostedMasterchef/boostedMasterchef.template.yaml
@@ -23,15 +23,15 @@ dataSources:
         - name: BoostedMasterChef
           file: ./abis/BoostedMasterChef.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: VeJoeToken
-          file: ../../node_modules/@traderjoe-xyz/core/abi/VeJoeToken.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/VeJoeToken.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
         - name: Rewarder
-          file: ../../node_modules/@traderjoe-xyz/core/abi/SimpleRewarderPerSec.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/SimpleRewarderPerSec.json
       eventHandlers:
         - event: Add(indexed uint256,uint256,uint256,indexed address,indexed address)
           handler: handleAdd

--- a/subgraphs/dexcandles/dexcandles.template.yaml
+++ b/subgraphs/dexcandles/dexcandles.template.yaml
@@ -26,7 +26,7 @@ dataSources:
         - Pair
       abis:
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core//abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core//abi/JoeFactory.json
       eventHandlers:
         - event: PairCreated(indexed address,indexed address,address,uint256)
           handler: handleNewPair
@@ -45,9 +45,9 @@ templates:
         - Pair
       abis:
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
       eventHandlers:
         - event: Swap(indexed address,uint256,uint256,uint256,uint256,indexed address)
           handler: handleSwap

--- a/subgraphs/dexcandles/package.json
+++ b/subgraphs/dexcandles/package.json
@@ -23,5 +23,8 @@
         "create-local": "graph create --node http://localhost:8020/ /sushiswap/sushiswap",
         "remove-local": "graph remove --node http://localhost:8020/ /sushiswap/sushiswap",
         "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 /sushiswap/sushiswap"
+    },
+    "dependencies": {
+        "@traderjoe-xyz/core": "^2.3.0"
     }
 }

--- a/subgraphs/exchange/package.json
+++ b/subgraphs/exchange/package.json
@@ -23,5 +23,8 @@
     "create-local": "graph create --node http://localhost:8020/ traderjoe-xyz/exchange-fuji",
     "remove-local": "graph remove --node http://localhost:8020/ traderjoe-xyz/exchange-fuji",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 traderjoe-xyz/exchange-fuji exchange.fuji.yaml"
+  },
+  "dependencies": {
+    "@traderjoe-xyz/core": "^2.3.0"
   }
 }

--- a/subgraphs/maker/maker.template.yaml
+++ b/subgraphs/maker/maker.template.yaml
@@ -21,13 +21,13 @@ dataSources:
         - Serving
       abis:
         - name: JoeMaker 
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeMaker.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeMaker.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
       eventHandlers:
         - event: LogConvert(indexed address,indexed address,indexed address,uint256,uint256,uint256)
           handler: handleLogConvert

--- a/subgraphs/maker/package.json
+++ b/subgraphs/maker/package.json
@@ -22,5 +22,8 @@
         "create-local": "graph create --node http://localhost:8020/ traderjoe-xyz/maker --access-token ",
         "remove-local": "graph remove --node http://localhost:8020/ traderjoe-xyz/maker --access-token ",
         "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 --access-token traderjoe-xyz/maker maker.fuji.yaml"
+    },
+    "dependencies": {
+        "@traderjoe-xyz/core": "^2.3.0"
     }
 }

--- a/subgraphs/makerV2/makerV2.template.yaml
+++ b/subgraphs/makerV2/makerV2.template.yaml
@@ -21,13 +21,13 @@ dataSources:
         - Serving
       abis:
         - name: JoeMakerV2
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeMakerV2.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeMakerV2.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
       eventHandlers:
         - event: LogConvert(indexed address,indexed address,indexed address,uint256,uint256,uint256)
           handler: handleLogConvert

--- a/subgraphs/makerV2/package.json
+++ b/subgraphs/makerV2/package.json
@@ -19,5 +19,8 @@
         "create-local": "graph create --node http://localhost:8020/ traderjoe-xyz/maker-v2 --access-token ",
         "remove-local": "graph remove --node http://localhost:8020/ traderjoe-xyz/maker-v2 --access-token ",
         "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 --access-token traderjoe-xyz/makerV2 makerV2.fuji.yaml"
+    },
+    "dependencies": {
+        "@traderjoe-xyz/core": "^2.3.0"
     }
 }

--- a/subgraphs/masterchef/masterchef.template.yaml
+++ b/subgraphs/masterchef/masterchef.template.yaml
@@ -23,13 +23,13 @@ dataSources:
         - User
       abis:
         - name: MasterChef
-          file: ../../node_modules/@traderjoe-xyz/core/abi/MasterChefJoe.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/MasterChefJoe.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
       eventHandlers:
         - event: Deposit(indexed address,indexed uint256,uint256)
           handler: deposit

--- a/subgraphs/masterchef/package.json
+++ b/subgraphs/masterchef/package.json
@@ -23,5 +23,8 @@
         "create-local": "graph create --node http://localhost:8020/ traderjoe-xyz/masterchef",
         "remove-local": "graph remove --node http://localhost:8020/ traderjoe-xyz/masterchef",
         "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 traderjoe-xyz/masterchef masterchef.fuji.yaml"
+    },
+    "dependencies": {
+        "@traderjoe-xyz/core": "^2.3.0"
     }
 }

--- a/subgraphs/masterchefV2/masterchefV2.template.yaml
+++ b/subgraphs/masterchefV2/masterchefV2.template.yaml
@@ -24,15 +24,15 @@ dataSources:
         - Rewarder
       abis:
         - name: MasterChefJoeV2
-          file: ../../node_modules/@traderjoe-xyz/core/abi/MasterChefJoeV2.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/MasterChefJoeV2.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
         - name: Rewarder
-          file: ../../node_modules/@traderjoe-xyz/core/abi/SimpleRewarderPerSec.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/SimpleRewarderPerSec.json
       eventHandlers:
         - event: Deposit(indexed address,indexed uint256,uint256)
           handler: deposit

--- a/subgraphs/masterchefV2/package.json
+++ b/subgraphs/masterchefV2/package.json
@@ -21,5 +21,7 @@
         "remove-local": "graph remove --node http://localhost:8020/ traderjoe-xyz/masterchefV2",
         "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 traderjoe-xyz/masterchefV2 masterchefV2.fuji.yaml"
     },
-    "dependencies": {}
+    "dependencies": {
+        "@traderjoe-xyz/core": "^2.3.0"
+    }
 }

--- a/subgraphs/masterchefV3/masterchefV3.template.yaml
+++ b/subgraphs/masterchefV3/masterchefV3.template.yaml
@@ -24,15 +24,15 @@ dataSources:
         - Rewarder
       abis:
         - name: MasterChefJoeV3
-          file: ../../node_modules/@traderjoe-xyz/core/abi/MasterChefJoeV3.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/MasterChefJoeV3.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
         - name: Rewarder
-          file: ../../node_modules/@traderjoe-xyz/core/abi/SimpleRewarderPerSec.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/SimpleRewarderPerSec.json
       eventHandlers:
         - event: Deposit(indexed address,indexed uint256,uint256)
           handler: deposit

--- a/subgraphs/moneymaker/moneymaker.template.yaml
+++ b/subgraphs/moneymaker/moneymaker.template.yaml
@@ -22,13 +22,13 @@ dataSources:
         - DayData
       abis:
         - name: MoneyMaker
-          file: ../../node_modules/@traderjoe-xyz/core/abi/MoneyMaker.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/MoneyMaker.json
         - name: ERC20
-          file: ../../node_modules/@traderjoe-xyz/core/abi/ERC20.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/ERC20.json
         - name: Factory
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoeFactory.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
       eventHandlers:
         - event: LogConvert(indexed address,indexed address,indexed address,uint256,uint256,uint256)
           handler: handleLogConvert

--- a/subgraphs/moneymaker/package.json
+++ b/subgraphs/moneymaker/package.json
@@ -19,5 +19,8 @@
     "create-local": "graph create --node http://localhost:8020/ traderjoe-xyz/moneymaker-fuji",
     "remove-local": "graph remove --node http://localhost:8020/ traderjoe-xyz/moneymaker-fuji",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001  traderjoe-xyz/moneymaker-fuji moneymaker.fuji.yaml"
+  },
+  "dependencies": {
+    "@traderjoe-xyz/core": "^2.3.0"
   }
 }

--- a/subgraphs/stablejoe/package.json
+++ b/subgraphs/stablejoe/package.json
@@ -19,5 +19,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ traderjoe-xyz/sjoe-fuji",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 traderjoe-xyz/sjoe-fuji stablejoe.fuji.yaml"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@traderjoe-xyz/core": "^2.3.0"
+  }
 }

--- a/subgraphs/stablejoe/stablejoe.template.yaml
+++ b/subgraphs/stablejoe/stablejoe.template.yaml
@@ -21,9 +21,9 @@ dataSources:
         - StableJoeDayData
       abis:
         - name: StableJoeStaking
-          file: ../../node_modules/@traderjoe-xyz/core/abi/StableJoeStaking.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/StableJoeStaking.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
       eventHandlers:
         - event: ClaimReward(indexed address,indexed address,uint256)
           handler: handleClaimReward

--- a/subgraphs/vejoe/package.json
+++ b/subgraphs/vejoe/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.26.0",
-    "@graphprotocol/graph-ts": "0.24.1"
+    "@graphprotocol/graph-ts": "0.24.1",
+    "@traderjoe-xyz/core": "^2.3.0"
   }
 }

--- a/subgraphs/vejoe/vejoe.template.yaml
+++ b/subgraphs/vejoe/vejoe.template.yaml
@@ -23,7 +23,7 @@ dataSources:
         - name: VeJoeStaking
           file: ./abis/VeJoeStaking.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
       eventHandlers:
         - event: Claim(indexed address,uint256)
           handler: handleClaim

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,9 +1637,9 @@ gluegun@^4.3.1:
     which "^2.0.0"
     yargs-parser "^16.1.0"
 
-"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
+"gluegun@https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep":
   version "4.3.1"
-  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
+  resolved "https://github.com/edgeandnode/gluegun#b34b9003d7bf556836da41b57ef36eb21570620a"
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"


### PR DESCRIPTION
When deploying subgraphs, we've been observing an error thrown from TheGraph's IPFS upload endpoint: `Failed to upload subgraph to IPFS: Failed to upload file to IPFS` 

Their ipfs server seems to be blocking uploads with abi imports outside of the subgraph's directory. Therefore, in this PR we do the following:

- Change abi imports in `*.template.yaml` files from `../../node_modules/*` to `./node_modules`
- Add '@traderjoe-xyz/core` dependency to all subgraph's `package.json`
- Add a `nohoist` clause in the project root's `package.json` in order to tell `yarn workspaces` not to hoist up the `@traderjoe-xyz/core` dependency 