### PR TITLE
Compute getJoePrice() from USDC/WAVAX and WAVAX/JOE rates

### DIFF
--- a/packages/constants/config/avax.json
+++ b/packages/constants/config/avax.json
@@ -16,6 +16,7 @@
   "vejoeToken_address": "0x3cabf341943Bc8466245e4d6F1ae0f8D071a1456",
   "joe_token_address": "0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd",
   "joe_usdt_pair_address": "0x1643de2efb8e35374d796297a9f95f64c082a8ce",
+  "joe_wavax_pair_address": "0x454e67025631c065d3cfad6d71e6892f74487a15",
 
   "wavax_address": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
   "weth_address": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
@@ -31,7 +32,7 @@
   "mim_address": "0x130966628846bfd36ff31a822705796e8cb8c18d",
   "wavax_usdt_pair_address": "0xed8cbd9f0ce3c6986b22002f03c6475ceb7a6256",
   "wavax_dai_pair_address": "0x87dee1cc9ffd464b79e058ba20387c1984aed86a",
-  "wavax_usdc_pair_address": "0xa389f9430876455c36478deea9769b7ca4e3ddb1",
+  "wavax_usdc_pair_address": "0xf4003f4efbe8691b60249e6afbd307abe7758adb",
   "wavax_mim_pair_address": "0x781655d802670bba3c89aebaaea59d3182fd755d",
 
   "zero_address": "0x0000000000000000000000000000000000000000"

--- a/packages/constants/config/fuji.json
+++ b/packages/constants/config/fuji.json
@@ -16,6 +16,7 @@
 
   "joe_token_address": "0x477Fd10Db0D80eAFb773cF623B258313C3739413",
   "joe_usdt_pair_address": "0xd520cf33c013909afc9cf158d73f5460753b5ec4",
+  "joe_wavax_pair_address":"0x6ed081838c9025118e5726de9f1052dda487a050",
 
   "wavax_address": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
   "wbtc_address": "0x106Dc78d638527b84572e5B077B76250adD0A988",

--- a/packages/constants/index.template.ts
+++ b/packages/constants/index.template.ts
@@ -55,6 +55,8 @@ export const JOE_MAKER_V2_ADDRESS = Address.fromString('{{ joe_makerV2_address }
 // PRICING
 export const TRADERJOE_WAVAX_USDT_PAIR_ADDRESS = Address.fromString('{{ wavax_usdt_pair_address }}')
 export const JOE_USDT_PAIR_ADDRESS = Address.fromString('{{ joe_usdt_pair_address }}')
+export const JOE_WAVAX_PAIR_ADDRESS = Address.fromString('{{ joe_wavax_pair_address }}')
+export const WAVAX_USDC_PAIR_ADDRESS = Address.fromString('{{ wavax_usdc_pair_address }}')
 
 // VEJOE 
 export const VEJOE_TOKEN_ADDRESS = Address.fromString('{{ vejoeToken_address }}')

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -55,6 +55,8 @@ export const JOE_MAKER_V2_ADDRESS = Address.fromString('0xC98C3C547DDbcc0029F38E
 // PRICING
 export const TRADERJOE_WAVAX_USDT_PAIR_ADDRESS = Address.fromString('0xed8cbd9f0ce3c6986b22002f03c6475ceb7a6256')
 export const JOE_USDT_PAIR_ADDRESS = Address.fromString('0x1643de2efb8e35374d796297a9f95f64c082a8ce')
+export const JOE_WAVAX_PAIR_ADDRESS = Address.fromString('0x454e67025631c065d3cfad6d71e6892f74487a15')
+export const WAVAX_USDC_PAIR_ADDRESS = Address.fromString('0xf4003f4efbe8691b60249e6afbd307abe7758adb')
 
 // VEJOE 
 export const VEJOE_TOKEN_ADDRESS = Address.fromString('0x3cabf341943Bc8466245e4d6F1ae0f8D071a1456')
@@ -69,7 +71,7 @@ export const MIM_ADDRESS = Address.fromString('0x130966628846bfd36ff31a822705796
 export const WAVAX_STABLE_PAIRS: string[] = [
     '0xed8cbd9f0ce3c6986b22002f03c6475ceb7a6256', // WAVAX-USDT
     '0x87dee1cc9ffd464b79e058ba20387c1984aed86a', // WAVAX-DAI
-    '0xa389f9430876455c36478deea9769b7ca4e3ddb1', // WAVAX-USDC
+    '0xf4003f4efbe8691b60249e6afbd307abe7758adb', // WAVAX-USDC
     '0x781655d802670bba3c89aebaaea59d3182fd755d', // WAVAX-USDC
 ]
 

--- a/subgraphs/stablejoe/src/mappings/stablejoe.ts
+++ b/subgraphs/stablejoe/src/mappings/stablejoe.ts
@@ -1,9 +1,10 @@
 import { Address, BigDecimal, BigInt, dataSource, ethereum, log } from '@graphprotocol/graph-ts'
 import {
-  BIG_DECIMAL_1E18,
-  BIG_DECIMAL_1E6,
+  BIG_DECIMAL_1E12,
   BIG_DECIMAL_ZERO,
-  JOE_USDT_PAIR_ADDRESS,
+  JOE_WAVAX_PAIR_ADDRESS,
+  WAVAX_USDC_PAIR_ADDRESS,
+  WAVAX_ADDRESS,
   USDC_ADDRESS,
   USDC_E_ADDRESS,
 } from 'const'
@@ -18,18 +19,51 @@ import { Pair as PairContract } from '../../generated/StableJoeStaking/Pair'
 import { getStableJoeDayData } from '../entities'
 
 function getJoePrice(): BigDecimal {
-  const pair = PairContract.bind(JOE_USDT_PAIR_ADDRESS)
-  const reservesResult = pair.try_getReserves()
-  if (reservesResult.reverted) {
-    log.info('[getJoePrice] getReserves reverted', [])
+  
+  // get AVAX/JOE rate
+  const avaxJoePair = PairContract.bind(JOE_WAVAX_PAIR_ADDRESS)
+  const avaxJoeReserves = avaxJoePair.getReserves()
+  const avaxJoeToken0 = avaxJoePair.token0()
+
+  const avaxReserve =
+    avaxJoeToken0.toHexString() === WAVAX_ADDRESS.toHexString()
+      ? avaxJoeReserves.value0.toBigDecimal()
+      : avaxJoeReserves.value1.toBigDecimal() // 18 decimals
+
+  const joeReserve =
+    avaxJoeToken0.toHexString() === WAVAX_ADDRESS.toHexString()
+      ? avaxJoeReserves.value1.toBigDecimal()
+      : avaxJoeReserves.value0.toBigDecimal() // 18 decimals
+
+  if (joeReserve.equals(BIG_DECIMAL_ZERO)) {
     return BIG_DECIMAL_ZERO
   }
-  const reserves = reservesResult.value
-  if (reserves.value0.toBigDecimal().equals(BigDecimal.fromString('0'))) {
-    log.error('[getJoePrice] USDT reserve 0', [])
+
+  const avaxJoeRate = avaxReserve.div(joeReserve)
+
+  // get USDC/AVAX rate
+  const usdcAvaxPair = PairContract.bind(WAVAX_USDC_PAIR_ADDRESS)
+  const usdcAvaxReserves = usdcAvaxPair.getReserves()
+  const usdcAvaxToken0 = usdcAvaxPair.token0()
+
+  const usdcReserve =
+    usdcAvaxToken0.toHexString() === WAVAX_ADDRESS.toHexString()
+      ? usdcAvaxReserves.value1.toBigDecimal().times(BIG_DECIMAL_1E12)
+      : usdcAvaxReserves.value0.toBigDecimal().times(BIG_DECIMAL_1E12) // 6 + 12 decimals
+
+  const _avaxReserve =
+    usdcAvaxToken0.toHexString() === WAVAX_ADDRESS.toHexString()
+      ? usdcAvaxReserves.value0.toBigDecimal()
+      : usdcAvaxReserves.value1.toBigDecimal() // 18 decimals
+
+  if (_avaxReserve.equals(BIG_DECIMAL_ZERO)) {
     return BIG_DECIMAL_ZERO
   }
-  return reserves.value1.toBigDecimal().times(BIG_DECIMAL_1E18).div(reserves.value0.toBigDecimal()).div(BIG_DECIMAL_1E6)
+
+  const usdcAvaxRate = usdcReserve.div(_avaxReserve)
+
+  // return USDC/JOE rate
+  return avaxJoeRate.times(usdcAvaxRate)
 }
 
 export function convertAmountToDecimal(tokenAmount: BigInt): BigDecimal {

--- a/subgraphs/stablejoe/stablejoe.avax.yaml
+++ b/subgraphs/stablejoe/stablejoe.avax.yaml
@@ -21,9 +21,9 @@ dataSources:
         - StableJoeDayData
       abis:
         - name: StableJoeStaking
-          file: ../../node_modules/@traderjoe-xyz/core/abi/StableJoeStaking.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/StableJoeStaking.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
       eventHandlers:
         - event: ClaimReward(indexed address,indexed address,uint256)
           handler: handleClaimReward

--- a/subgraphs/stablejoe/stablejoe.fuji.yaml
+++ b/subgraphs/stablejoe/stablejoe.fuji.yaml
@@ -21,9 +21,9 @@ dataSources:
         - StableJoeDayData
       abis:
         - name: StableJoeStaking
-          file: ../../node_modules/@traderjoe-xyz/core/abi/StableJoeStaking.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/StableJoeStaking.json
         - name: Pair
-          file: ../../node_modules/@traderjoe-xyz/core/abi/JoePair.json
+          file: ./node_modules/@traderjoe-xyz/core/abi/JoePair.json
       eventHandlers:
         - event: ClaimReward(indexed address,indexed address,uint256)
           handler: handleClaimReward


### PR DESCRIPTION
Updated `getJoePrice()`  to compute USDC/JOE rate in **vejoe** and **stablejoe** subgraphs